### PR TITLE
Translation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,3 +69,5 @@ end
 gem "tailwindcss-rails", "~> 2.4"
 
 gem "webpacker", "~> 5.4"
+
+gem 'i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -282,6 +282,7 @@ DEPENDENCIES
   bootsnap
   capybara
   debug
+  i18n
   importmap-rails
   jbuilder
   puma (>= 5.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,12 @@
 class ApplicationController < ActionController::Base
+  before_action :set_locale
+
+  def set_locale
+    I18n.locale = params[:locale] || I18n.default_locale
+  end
+
+  # Este método pode ser usado para incluir o locale nos links
+  def default_url_options
+    { locale: I18n.locale }
+  end
 end

--- a/app/views/leads/_lead.html.erb
+++ b/app/views/leads/_lead.html.erb
@@ -1,6 +1,6 @@
 <div id="<%= dom_id lead %>">
   <p class="my-5">
-    <strong class="block font-medium mb-1">Name:</strong>
+    <strong class="block font-medium mb-1"><%= t('views.common.name') %>:</strong>
     <%= lead.name %>
   </p>
 
@@ -10,13 +10,13 @@
   </p>
 
   <p class="my-5">
-    <strong class="block font-medium mb-1">Phone:</strong>
+    <strong class="block font-medium mb-1"><%= t('activerecord.attributes.lead.phone') %>:</strong>
     <%= lead.phone %>
   </p>
 
   <% if action_name != "show" %>
-    <%= link_to "Show this lead", lead, class: "rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
-    <%= link_to "Edit this lead", edit_lead_path(lead), class: "rounded-lg py-3 ml-2 px-5 bg-gray-100 inline-block font-medium" %>
+    <%= link_to t('leads.show.show_lead'), lead, class: "rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+    <%= link_to t('leads.show.edit_lead'), edit_lead_path(lead), class: "rounded-lg py-3 ml-2 px-5 bg-gray-100 inline-block font-medium" %>
     <hr class="mt-6">
   <% end %>
 </div>

--- a/app/views/leads/index.html.erb
+++ b/app/views/leads/index.html.erb
@@ -5,7 +5,7 @@
 
   <div class="flex justify-between items-center">
     <h1 class="font-bold text-4xl">Leads</h1>
-    <%= link_to "New lead", new_lead_path, class: "rounded-lg py-3 px-5 bg-blue-600 text-white block font-medium" %>
+    <%= link_to t('views.common.new_lead'), new_lead_path, class: "rounded-lg py-3 px-5 bg-blue-600 text-white block font-medium" %>
   </div>
 
   <div id="leads" class="min-w-full">

--- a/app/views/leads/new.html.erb
+++ b/app/views/leads/new.html.erb
@@ -3,5 +3,5 @@
 
   <%= render "form", lead: @lead %>
 
-  <%= link_to "Back to leads", leads_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+  <%= link_to t('views.common.back_to_leads'), leads_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
 </div>

--- a/app/views/leads/show.html.erb
+++ b/app/views/leads/show.html.erb
@@ -6,10 +6,10 @@
 
     <%= render @lead %>
 
-    <%= link_to "Edit this lead", edit_lead_path(@lead), class: "mt-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+    <%= link_to t('views.common.edit_lead'), edit_lead_path(@lead), class: "mt-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
     <div class="inline-block ml-2">
-      <%= button_to "Destroy this lead", lead_path(@lead), method: :delete, class: "mt-2 rounded-lg py-3 px-5 bg-gray-100 font-medium" %>
+      <%= button_to t('views.common.destroy_lead'), lead_path(@lead), method: :delete, class: "mt-2 rounded-lg py-3 px-5 bg-gray-100 font-medium" %>
     </div>
-    <%= link_to "Back to leads", leads_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+    <%= link_to t('views.common.back_to_leads'), leads_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,4 +28,38 @@
 #       enabled: "ON"
 
 en:
-  hello: "Hello world"
+  errors:
+    template:
+      header:
+        one: "%{count} error prohibited this %{model} from being saved:"
+        other: "%{count} error prohibited this %{model} from being saved:"
+    lead:
+      name: "Name"
+      phone: "Phone"
+    index:
+      title: "Leads"
+      new_lead: "New lead"
+      notice: "Lead was successfully created"
+    new:
+      title: "New Lead"
+      back_to_leads: "Back to leads"
+    edit:
+      title: "Edit Lead"
+      back_to_leads: "Back to leads"
+    show:
+      show_lead: "Show this lead"
+      edit_lead: "Edit this lead"
+      destroy_lead: "Destroy this lead"
+    form:
+      name: "Name"
+      phone: "Phone"
+      submit: "Save Lead"
+  views:
+    common:
+      name: "Name"
+      phone: "Phone"
+      show_lead: "Show this lead"
+      edit_lead: "Edit this lead"
+      back_to_leads: "Back to leads"
+      destroy_lead: "Destroy this lead"
+      new_lead: "New lead"

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -13,11 +13,35 @@ pt-BR:
         one: "%{count} erro impediu que este %{model} fosse salvo:"
         other: "%{count} erros impediram que este %{model} fosse salvo:"
       body: "Houve problemas com os seguintes campos:"
+      attributes:
+            email:
+              blank: "não pode ficar em branco"
+              invalid: "não é válido"
+            name:
+              blank: "não pode ficar em branco"
+            phone:
+              blank: "não pode ficar em branco"
+      messages:
+        record_invalid: "A validação falhou: %{errors}"
+  errors:
+    format: "%{attribute} %{message}"
+    messages:
+      blank: "não pode ficar em branco"
+      invalid: "não é válido"
+      taken: "já está em uso"
+    template:
+      header:
+        one: "%{count} erro impediu que este %{model} fosse salvo:"
+        other: "%{count} erros impediram que este %{model} fosse salvo:"
+      body: "Houve problemas com os seguintes campos:"
   helpers:
     submit:
       create: "Criar %{model}"
       update: "Atualizar %{model}"
   leads:
+    lead:
+      name: "Nome"
+      phone: "Telefone"
     index:
       title: "Leads"
       new_lead: "Novo Lead"
@@ -31,8 +55,17 @@ pt-BR:
     show:
       show_lead: "Mostrar este Lead"
       edit_lead: "Editar este Lead"
+      destroy_lead: "Excluir este Lead"
     form:
       name: "Nome"
-      email: "Email"
       phone: "Telefone"
       submit: "Salvar Lead"
+  views:
+    common:
+      name: "Nome"
+      phone: "Telefone"
+      show_lead: "Mostrar este Lead"
+      edit_lead: "Editar este Lead"
+      back_to_leads: "Voltar para Leads"
+      destroy_lead: "Excluir este Lead"
+      new_lead: "Novo Lead"


### PR DESCRIPTION
Sintaxe error and method fix in config/application.rb at line 18 and 19
Change sixtaxe from "congig" to "config"
Changed previous existing method to the config.i18n.available_locales = [:en, :'pt-BR'] at line 18
Added default method config.i18n.default_locale = :'pt-BR' at line 19
Added config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s] at line 22
Added i18n gem
Created locales files en.yml and pt-BR.yml at cinfig/locales
Changed text to translate in these files:
_lead.html.erb
"Name" at line 3
"Phone" at line 13
"Show This lead" at line 18
"Edit this lead" at line 19
index.html.erb
"New lead" at line 8
new.html.erb
"Back to leads" at line 6
show.html.erb
"Edit this lead" at line 9
"Destroy this lead" at line 11
"Back to leads" at line 13